### PR TITLE
Add support for fetchOnServer as a function

### DIFF
--- a/src/nuxt-property-decorator.ts
+++ b/src/nuxt-property-decorator.ts
@@ -21,6 +21,7 @@ Component.registerHooks([
   "beforeRouteLeave",
   "asyncData",
   "fetch",
+  "fetchOnServer",
   "head",
   "key",
   "layout",


### PR DESCRIPTION
# Description

This PR adds support for the `fetchOnServer` hook for Nuxt (https://nuxtjs.org/api/pages-fetch/#options).

Note: This hook only seems to work as a function, and not when given a boolean directly. I am unsure how to resolve that. If anyone can point me in the right direction, I will update this PR.

Resolves #72 