### PR TITLE
Add support for fetchDelay as a function

### DIFF
--- a/src/nuxt-property-decorator.ts
+++ b/src/nuxt-property-decorator.ts
@@ -11,6 +11,7 @@ Component.registerHooks([
   "asyncData",
   "fetch",
   "fetchOnServer",
+  "fetchDelay",
   "head",
   "key",
   "layout",


### PR DESCRIPTION
<h1> Description </h1>

This PR adds support for the fetchDelay option for Nuxt (https://nuxtjs.org/api/pages-fetch/#options).

Note: This hook only seems to work as a function, same as #72 , and not when assigned an integer value. I'll update the PR if there are any comments. 

Resolves #96 