### PR TITLE
feat: Expose PropType from Vue

### DIFF
--- a/lib/nuxt-property-decorator.d.ts
+++ b/lib/nuxt-property-decorator.d.ts
@@ -1,6 +1,6 @@
 import Vue from "vue";
-import Component, { mixins } from "vue-class-component";
-export { Vue, Component, mixins };
+import Component, { mixins, PropType } from "vue-class-component";
+export { Vue, Component, mixins, PropType };
 export { Module, getModule, VuexModule, Mutation as VuexMutation, MutationAction, Action as VuexAction, } from "vuex-module-decorators";
 export { State, Getter, Action, Mutation, namespace } from "vuex-class";
 export { Emit, Inject, InjectReactive, Model, ModelSync, Prop, PropSync, Provide, ProvideReactive, Ref, VModel, Watch, } from "vue-property-decorator";

--- a/src/nuxt-property-decorator.ts
+++ b/src/nuxt-property-decorator.ts
@@ -1,6 +1,6 @@
 "use strict"
 
-import Vue, { PropOptions, WatchOptions } from "vue"
+import Vue, { PropOptions, PropType, WatchOptions } from "vue"import Vue, { PropOptions, PropType, WatchOptions } from "vue"
 
 import Component, { createDecorator, mixins } from "vue-class-component"
 
@@ -23,7 +23,7 @@ Component.registerHooks([
   "meta",
 ])
 
-export { Vue, Component, mixins }
+export { Vue, Component, mixins, PropType }
 
 export {
   Module,


### PR DESCRIPTION
PropType are mainly used as a help tools when declaring a Prop that takes an interface type. This would allow PropType to be imported via `nuxt-property-decorator` instead from `Vue`

Closes  #101 